### PR TITLE
Persistent requires more language extensions since v2.10.5

### DIFF
--- a/src/Snap/Snaplet/Auth/Backends/Persistent/Types.hs
+++ b/src/Snap/Snaplet/Auth/Backends/Persistent/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies         #-}
 {-# LANGUAGE EmptyDataDecls             #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GADTs                      #-}
@@ -5,8 +6,10 @@
 {-# LANGUAGE MultiParamTypeClasses      #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RecordWildCards            #-}
+{-# LANGUAGE StandaloneDeriving         #-}
 {-# LANGUAGE TemplateHaskell            #-}
 {-# LANGUAGE TypeFamilies               #-}
+{-# LANGUAGE UndecidableInstances       #-}
 
 
 module Snap.Snaplet.Auth.Backends.Persistent.Types where


### PR DESCRIPTION
Persistent requires additional language extensions [since version 2.10.5](https://github.com/yesodweb/persistent/commit/6ca1c2401f228293c64ae05e6109d4936b98c4b9):
